### PR TITLE
sepolicy: Allow platform_app to bypass the FUSE layer

### DIFF
--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -7,5 +7,8 @@ hal_client_domain(platform_app, hal_lineage_fastcharge)
 # Allow LiveDisplay HAL service to be found
 hal_client_domain(platform_app, hal_lineage_livedisplay)
 
+# Allow bypassing the FUSE layer
+r_dir_file(platform_app, mnt_pass_through_file)
+
 # Allow PowerShare HAL service to be found
 hal_client_domain(platform_app, hal_lineage_powershare)


### PR DESCRIPTION
Needed for cross-user file access through documentsui.

Change-Id: I787da6e7b0d7006a4dbbadb338c36b06dd3d4c16
Signed-off-by: LibXZR <i@xzr.moe>