### PR TITLE
Allow -user built recoveries to flash custom zips such as Magisk

### DIFF
--- a/common/private/recovery.te
+++ b/common/private/recovery.te
@@ -1,7 +1,5 @@
 recovery_only(`
-userdebug_or_eng(`
 permissive recovery;
-')
 
 # Volume manager
 r_dir_file(recovery, sdcard_type)


### PR DESCRIPTION
Permissive recovery domain is now allowed in user builds.

Change-Id: I57711bc63a40c2e941d417489af781bed6ee61fc